### PR TITLE
Remove gateway from InfiniBand subnet (alt-1)

### DIFF
--- a/etc/p3-config/p3-config.yml
+++ b/etc/p3-config/p3-config.yml
@@ -376,7 +376,6 @@ p3_subnet_lln:
   name: "{{ p3_network_lln_name }}"
   cidr: "10.2.0.0/24"
   enable_dhcp: false
-  gateway_ip: "10.2.0.1"
   allocation_pool_start: "10.2.0.2"
   allocation_pool_end: "10.2.0.254"
 


### PR DESCRIPTION
This IP was previously assigned to the controller, but is not anymore.