### PR TITLE
Remove dns nameserver on p3-bdn

### DIFF
--- a/etc/p3-config/p3-config.yml
+++ b/etc/p3-config/p3-config.yml
@@ -503,7 +503,7 @@ p3_subnet_bdn:
   cidr: "10.1.0.0/24"
   allocation_pool_start: "10.1.0.1"
   dns_nameservers:
-  - "8.8.8.8"
+  - "0.0.0.0"
   allocation_pool_end: "10.1.0.254"
 
 # P3 Low Latency Network (LLN) network name.


### PR DESCRIPTION
Currently nameservers are provided by both ilab (neutron) and bdn (google) networks but only the former can resolve internal names. With two nameservers which one instances have set on creation is indeterminate but in practice has always been bdn, hence instances cannot resolve internal names. This change fixes this by disabling the nameserver on bdn.